### PR TITLE
Use specific minio image to make it reliable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -90,7 +90,8 @@ services:
       - schema-registry
 
   minio:
-    image: minio/minio
+    image: minio/minio:RELEASE.2021-02-11T08-23-43Z
+    container_name: s3
     ports:
       - "9000:9000"
     command:
@@ -98,6 +99,7 @@ services:
 
   aws:
     image: amazon/aws-cli
+    container_name: aws-cli
     command: -c "sleep 2 && aws --endpoint-url http://minio:9000 s3 mb s3://test --region eu-west-1 || exit 0"
     entrypoint: [/bin/bash]
     environment: 


### PR DESCRIPTION
In case of breaking changes in minio, the stack won't work. We want to use a specific minio image that we know works.